### PR TITLE
뉴스/ 블로그 결과에 필요한 ArticleView 생성

### DIFF
--- a/SearchApp/SearchApp.xcodeproj/project.pbxproj
+++ b/SearchApp/SearchApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7B2419F928BF4C920023F715 /* SearchAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2419F828BF4C920023F715 /* SearchAppTests.swift */; };
 		7B241A0328BF4C920023F715 /* SearchAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B241A0228BF4C920023F715 /* SearchAppUITests.swift */; };
 		7B241A0528BF4C920023F715 /* SearchAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */; };
+		7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A7BF428BF5046001E50FD /* ArticleView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -44,6 +45,7 @@
 		7B2419FE28BF4C920023F715 /* SearchAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SearchAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B241A0228BF4C920023F715 /* SearchAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAppUITests.swift; sourceTree = "<group>"; };
 		7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		7B7A7BF428BF5046001E50FD /* ArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -96,6 +98,7 @@
 			children = (
 				7B2419E728BF4C910023F715 /* SearchAppApp.swift */,
 				7B2419E928BF4C910023F715 /* ContentView.swift */,
+				7B7A7BF328BF502C001E50FD /* Views */,
 				7B2419EB28BF4C920023F715 /* Assets.xcassets */,
 				7B2419ED28BF4C920023F715 /* Preview Content */,
 			);
@@ -125,6 +128,14 @@
 				7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */,
 			);
 			path = SearchAppUITests;
+			sourceTree = "<group>";
+		};
+		7B7A7BF328BF502C001E50FD /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				7B7A7BF428BF5046001E50FD /* ArticleView.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,6 +269,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B2419EA28BF4C910023F715 /* ContentView.swift in Sources */,
+				7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */,
 				7B2419E828BF4C910023F715 /* SearchAppApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SearchApp/SearchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/SearchApp/SearchApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/SearchApp/SearchApp/ContentView.swift
+++ b/SearchApp/SearchApp/ContentView.swift
@@ -9,8 +9,10 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        List {
+            ArticleView()
+            ArticleView()
+        }
     }
 }
 

--- a/SearchApp/SearchApp/Views/ArticleView.swift
+++ b/SearchApp/SearchApp/Views/ArticleView.swift
@@ -1,0 +1,51 @@
+//
+//  ArticleView.swift
+//  SearchApp
+//
+//  Created by 최은주 on 2022/08/31.
+//
+
+import SwiftUI
+
+struct ArticleView: View {
+    var body: some View {
+        HStack {
+            Image(systemName: "photo.on.rectangle.angled")
+                .foregroundColor(.gray)
+                .frame(width: 70, height: 70)
+                .cornerRadius(15.0)
+            
+            VStack(alignment: .leading) {
+                Text("Title")
+                    .font(.headline)
+                    .fontWeight(.bold)
+                
+                Text("This is article text view. Line limit is 2. This is article text view. Line limit is 2.")
+                    .font(.system(size: 14.0))
+                    .fontWeight(.light)
+                    .lineLimit(2)
+                
+                HStack {
+                    //TODO: 데이터가 뉴스인 경우는 blog name과 divider가 나오지 않도록 수정
+                    Text("Blog Name")
+                        .fontWeight(.thin)
+                        .lineLimit(1)
+                    
+                    Divider().frame(width: 1, height: 10, alignment: .leading)
+                    
+                    Text("Date")
+                        .fontWeight(.thin)
+                }.font(.system(size: 11.0))
+            }
+            
+            Spacer()
+        }
+    }
+}
+
+struct ArticleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ArticleView()
+            .previewLayout(.fixed(width: 300, height: 100))
+    }
+}


### PR DESCRIPTION
## 수정사항
- 뉴스/ 블로그 결과에 필요한 ArticleView 생성
   - 이미지, 타이틀, 내용, 블로그명, 날짜가 나오도록 View를 구성

## 추후 수정해야 하는 사항
- 데이터가 뉴스인 경우는 blog name과 divider가 나오지 않도록 수정