### PR TITLE
앱 메인 화면 구현

### DIFF
--- a/SearchApp/SearchApp.xcodeproj/project.pbxproj
+++ b/SearchApp/SearchApp.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7B2419F928BF4C920023F715 /* SearchAppTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B2419F828BF4C920023F715 /* SearchAppTests.swift */; };
 		7B241A0328BF4C920023F715 /* SearchAppUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B241A0228BF4C920023F715 /* SearchAppUITests.swift */; };
 		7B241A0528BF4C920023F715 /* SearchAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */; };
+		7B45617D28C05327008CC18D /* SearchMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B45617C28C05327008CC18D /* SearchMainView.swift */; };
 		7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A7BF428BF5046001E50FD /* ArticleView.swift */; };
 /* End PBXBuildFile section */
 
@@ -45,6 +46,7 @@
 		7B2419FE28BF4C920023F715 /* SearchAppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SearchAppUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		7B241A0228BF4C920023F715 /* SearchAppUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAppUITests.swift; sourceTree = "<group>"; };
 		7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		7B45617C28C05327008CC18D /* SearchMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMainView.swift; sourceTree = "<group>"; };
 		7B7A7BF428BF5046001E50FD /* ArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -134,6 +136,7 @@
 			isa = PBXGroup;
 			children = (
 				7B7A7BF428BF5046001E50FD /* ArticleView.swift */,
+				7B45617C28C05327008CC18D /* SearchMainView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -268,6 +271,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7B45617D28C05327008CC18D /* SearchMainView.swift in Sources */,
 				7B2419EA28BF4C910023F715 /* ContentView.swift in Sources */,
 				7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */,
 				7B2419E828BF4C910023F715 /* SearchAppApp.swift in Sources */,

--- a/SearchApp/SearchApp/ContentView.swift
+++ b/SearchApp/SearchApp/ContentView.swift
@@ -9,9 +9,19 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        List {
-            ArticleView()
-            ArticleView()
+        GeometryReader { geometryproxy in
+            VStack {
+                Spacer().frame(width: geometryproxy.size.width, height: geometryproxy.size.height / 4, alignment: .center)
+                
+                SearchMainView()
+                    .padding(.bottom, 20)
+                
+                Spacer()
+                
+                Text("@Chenjoo")
+                    .font(.system(size: 12))
+                    .fontWeight(.heavy)
+            }
         }
     }
 }

--- a/SearchApp/SearchApp/Views/ArticleView.swift
+++ b/SearchApp/SearchApp/Views/ArticleView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ArticleView: View {
     var body: some View {
         HStack {
+            Spacer()
+            
             Image(systemName: "photo.on.rectangle.angled")
                 .foregroundColor(.gray)
                 .frame(width: 70, height: 70)

--- a/SearchApp/SearchApp/Views/SearchMainView.swift
+++ b/SearchApp/SearchApp/Views/SearchMainView.swift
@@ -1,0 +1,48 @@
+//
+//  SearchMainView.swift
+//  SearchApp
+//
+//  Created by 최은주 on 2022/09/01.
+//
+
+import SwiftUI
+
+struct SearchMainView: View {
+    @State private var keyword: String = ""
+    
+    var body: some View {
+        VStack {
+            Text("Search Everything")
+                .foregroundColor(.orange)
+                .font(.largeTitle)
+                .fontWeight(.heavy)
+            
+            HStack(spacing: 0) {
+                //TODO: Enter - 검색 API 조회
+                TextField("Input Search Text", text: $keyword)
+                    .frame(height: 50)
+                    .padding(.leading, 10)
+                
+                Button {
+                    //TODO: 검색 API 조회
+                } label: {
+                    Label("Search", systemImage: "magnifyingglass")
+                        .labelStyle(.iconOnly)
+                        .imageScale(.medium)
+                        .foregroundColor(.orange)
+                        .padding()
+                }
+            }
+            .border(.orange, width: 2)
+            .cornerRadius(3.0)
+            .padding(EdgeInsets(top: 0, leading: 10, bottom: 0, trailing: 10))
+        }
+        
+    }
+}
+
+struct SearchView_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchMainView()
+    }
+}


### PR DESCRIPTION
## 수정 사항
- 앱의 메인 화면인 검색창이 있는 SearchMainView 생성
   - 검색어를 입력할 TextField 추가
- ContentView에서 SearchMainView 호출
   - View의 위치를 지정하기 위해 GeometryReader 사용

## 추후 수정해야 하는 사항
- 검색 결과 화면 구현
- 검색 버튼 누르거나 엔터 입력시 검색 결과 화면으로 이동
   - API 조회 타이밍 고려하기

## 화면

<img src="https://user-images.githubusercontent.com/22000470/187859328-d8a9a76c-3d41-462c-8b7f-5a2ae7a6b6b3.png" width="300">