### PR TITLE
검색 api 결과 파싱 로직 추가

### DIFF
--- a/SearchApp/SearchApp.xcodeproj/project.pbxproj
+++ b/SearchApp/SearchApp.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		7B241A0528BF4C920023F715 /* SearchAppUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */; };
 		7B45617D28C05327008CC18D /* SearchMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B45617C28C05327008CC18D /* SearchMainView.swift */; };
 		7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B7A7BF428BF5046001E50FD /* ArticleView.swift */; };
+		7BB7BA5928CF2B8D00C698DD /* SearchType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7BA5828CF2B8D00C698DD /* SearchType.swift */; };
+		7BB7BA6428CF2CD600C698DD /* news.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BB7BA6128CF2CD600C698DD /* news.json */; };
+		7BB7BA6528CF2CD600C698DD /* image.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BB7BA6228CF2CD600C698DD /* image.json */; };
+		7BB7BA6628CF2CD600C698DD /* blog.json in Resources */ = {isa = PBXBuildFile; fileRef = 7BB7BA6328CF2CD600C698DD /* blog.json */; };
+		7BB7BA6828CF2CF200C698DD /* APIResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BB7BA6728CF2CF200C698DD /* APIResult.swift */; };
 		7BF6492528C49EA8002160E7 /* ResultListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6492428C49EA8002160E7 /* ResultListView.swift */; };
 		7BF6492828C4C0E8002160E7 /* SearchBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BF6492728C4C0E8002160E7 /* SearchBoxView.swift */; };
 /* End PBXBuildFile section */
@@ -58,6 +63,11 @@
 		7B241A0428BF4C920023F715 /* SearchAppUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAppUITestsLaunchTests.swift; sourceTree = "<group>"; };
 		7B45617C28C05327008CC18D /* SearchMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchMainView.swift; sourceTree = "<group>"; };
 		7B7A7BF428BF5046001E50FD /* ArticleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArticleView.swift; sourceTree = "<group>"; };
+		7BB7BA5828CF2B8D00C698DD /* SearchType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchType.swift; sourceTree = "<group>"; };
+		7BB7BA6128CF2CD600C698DD /* news.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = news.json; sourceTree = "<group>"; };
+		7BB7BA6228CF2CD600C698DD /* image.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = image.json; sourceTree = "<group>"; };
+		7BB7BA6328CF2CD600C698DD /* blog.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = blog.json; sourceTree = "<group>"; };
+		7BB7BA6728CF2CF200C698DD /* APIResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIResult.swift; sourceTree = "<group>"; };
 		7BF6492428C49EA8002160E7 /* ResultListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResultListView.swift; sourceTree = "<group>"; };
 		7BF6492728C4C0E8002160E7 /* SearchBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchBoxView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -93,6 +103,8 @@
 				7B21F86628C7777300419E1B /* Blog.swift */,
 				7B21F86828C7783A00419E1B /* News.swift */,
 				7B21F86A28C7786E00419E1B /* Photo.swift */,
+				7BB7BA5828CF2B8D00C698DD /* SearchType.swift */,
+				7BB7BA6728CF2CF200C698DD /* APIResult.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -151,6 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				7B2419F828BF4C920023F715 /* SearchAppTests.swift */,
+				7BB7BA6028CF2CD600C698DD /* APIResults */,
 			);
 			path = SearchAppTests;
 			sourceTree = "<group>";
@@ -172,6 +185,16 @@
 				7BF6492428C49EA8002160E7 /* ResultListView.swift */,
 			);
 			path = Views;
+			sourceTree = "<group>";
+		};
+		7BB7BA6028CF2CD600C698DD /* APIResults */ = {
+			isa = PBXGroup;
+			children = (
+				7BB7BA6128CF2CD600C698DD /* news.json */,
+				7BB7BA6228CF2CD600C698DD /* image.json */,
+				7BB7BA6328CF2CD600C698DD /* blog.json */,
+			);
+			path = APIResults;
 			sourceTree = "<group>";
 		};
 		7BF6492628C4C0B6002160E7 /* Main */ = {
@@ -296,6 +319,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BB7BA6428CF2CD600C698DD /* news.json in Resources */,
+				7BB7BA6528CF2CD600C698DD /* image.json in Resources */,
+				7BB7BA6628CF2CD600C698DD /* blog.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -314,9 +340,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B21F86E28C8DB2B00419E1B /* SearchAPI.swift in Sources */,
+				7BB7BA5928CF2B8D00C698DD /* SearchType.swift in Sources */,
 				7B45617D28C05327008CC18D /* SearchMainView.swift in Sources */,
 				7B21F86B28C7786E00419E1B /* Photo.swift in Sources */,
 				7B2419EA28BF4C910023F715 /* ContentView.swift in Sources */,
+				7BB7BA6828CF2CF200C698DD /* APIResult.swift in Sources */,
 				7B21F86928C7783A00419E1B /* News.swift in Sources */,
 				7B7A7BF528BF5046001E50FD /* ArticleView.swift in Sources */,
 				7BF6492528C49EA8002160E7 /* ResultListView.swift in Sources */,

--- a/SearchApp/SearchApp/API/SearchAPI.swift
+++ b/SearchApp/SearchApp/API/SearchAPI.swift
@@ -6,14 +6,13 @@
 //
 
 import Foundation
+import SwiftUI
 
-enum SearchType: String {
-    case blog
-    case news
-    case image
-}
-
-class SearchAPI {
+class SearchAPI: ObservableObject {
+    @Published var blogs: [Blog] = []
+    @Published var news: [News] = []
+    @Published var photos: [Photo] = []
+    
     private let baseURL = "https://openapi.naver.com/v1/search/"
     
     private enum ClientKey: String {
@@ -39,15 +38,36 @@ class SearchAPI {
     func requestSearchResult(startIndex: Int = 1, keyword: String) {
         guard let urlRequest = self.createURLRequest(keyword: keyword) else { return }
         
-        URLSession.shared.dataTask(with: urlRequest) { data, response, error in
-            // 결과값 파싱            
+        URLSession.shared.dataTask(with: urlRequest) {data, response, error in
+            // TODO: 에러 처리
+            
+            guard let data = data else { return }
+
+            let decoder = JSONDecoder()
+            
+            DispatchQueue.main.async {
+                switch self.searchType {
+                case .blog:
+                    if let result = try? decoder.decode(APIResult<Blog>.self, from: data) {
+                        self.blogs.append(contentsOf: result.items)
+                    }
+                case .news:
+                    if let result = try? decoder.decode(APIResult<News>.self, from: data) {
+                        self.news.append(contentsOf: result.items)
+                    }
+                case .image:
+                    if let result = try? decoder.decode(APIResult<Photo>.self, from: data) {
+                        self.photos.append(contentsOf: result.items)
+                    }
+                }
+            }
         }.resume()
     }
     
     private func createURLRequest(startIndex: Int = 1, keyword: String) -> URLRequest? {
         var urlComponents = URLComponents(string: baseURL + searchType.rawValue)
         
-        let query: URLQueryItem = URLQueryItem(name: "query", value: keyword.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed))
+        let query: URLQueryItem = URLQueryItem(name: "query", value: keyword)
         let start: URLQueryItem = URLQueryItem(name: "start", value: String(startIndex))
         urlComponents?.queryItems = [query, start]
         

--- a/SearchApp/SearchApp/Models/APIResult.swift
+++ b/SearchApp/SearchApp/Models/APIResult.swift
@@ -1,0 +1,16 @@
+//
+//  APIResult.swift
+//  SearchApp
+//
+//  Created by 최은주 on 2022/09/12.
+//
+
+import Foundation
+
+struct APIResult<T: Codable>: Codable {
+    let lastBuildDate: String
+    let total: Int
+    let start: Int
+    let display: Int
+    let items: [T]
+}

--- a/SearchApp/SearchApp/Models/Blog.swift
+++ b/SearchApp/SearchApp/Models/Blog.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Blog: Codable {
+struct Blog: Codable, Hashable {
     var title: String
     var link: String
     var description: String

--- a/SearchApp/SearchApp/Models/News.swift
+++ b/SearchApp/SearchApp/Models/News.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct News: Codable {
+struct News: Codable, Hashable {
     var title: String
     var link: String
     var description: String

--- a/SearchApp/SearchApp/Models/Photo.swift
+++ b/SearchApp/SearchApp/Models/Photo.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct Photo: Codable {
+struct Photo: Codable, Hashable {
     var title: String
     var link: String
     var thumbnail: String

--- a/SearchApp/SearchApp/Models/SearchType.swift
+++ b/SearchApp/SearchApp/Models/SearchType.swift
@@ -1,0 +1,14 @@
+//
+//  SearchType.swift
+//  SearchApp
+//
+//  Created by 최은주 on 2022/09/12.
+//
+
+import Foundation
+
+enum SearchType: String {
+    case blog
+    case news
+    case image
+}

--- a/SearchApp/SearchAppTests/APIResults/blog.json
+++ b/SearchApp/SearchAppTests/APIResults/blog.json
@@ -1,0 +1,88 @@
+{
+	"lastBuildDate":"Mon, 12 Sep 2022 15:36:04 +0900",
+	"total":45956175,
+	"start":1,
+	"display":10,
+	"items":[
+		{
+			"title":"남해 <b>여행<\/b> 먹거리 남해 전통시장 멸치쌈밥",
+			"link":"https:\/\/blog.naver.com\/wlsgml850?Redirect=Log&logNo=222853386542",
+			"description":"남해<b>여행<\/b>에서 하루는 지역의 명물인 남해 멸치쌈밥을 먹기 위해 전통시장을 찾았어요. 제가 사는 지역에도 멸치가 유명하긴 하지만 여긴 어떻게 다를까? 비교하면서 맛보는 재미를 느끼고 왔답니다. 남해 <b>여행<\/b>... ",
+			"bloggername":"트래블러버의 맛있는 여행",
+			"bloggerlink":"https:\/\/blog.naver.com\/wlsgml850",
+			"postdate":"20220912"
+		},
+		{
+			"title":"코타키나발루 <b>여행<\/b> 말레이시아 해외 휴양지 섬 투어",
+			"link":"https:\/\/blog.naver.com\/tcacyc?Redirect=Log&logNo=222866772499",
+			"description":"코타키나발루 <b>여행<\/b> 해외 휴양지 섬 투어 추석 연휴가 시작되는 한주가 되었습니다. 가을이 성큼성큼... 그런 더위에 지치면 지난 8월에 다녀온 말레이시아 <b>여행<\/b>이 생각나는데 특히 하루 종일 아름다운 바다에서... ",
+			"bloggername":"일상탈출",
+			"bloggerlink":"https:\/\/blog.naver.com\/tcacyc",
+			"postdate":"20220908"
+		},
+		{
+			"title":"다낭 자유<b>여행<\/b> : 영흥사 핑크성당 마사지까지 완벽",
+			"link":"https:\/\/blog.naver.com\/metalingus58?Redirect=Log&logNo=222871047656",
+			"description":"다낭 자유<b>여행<\/b> 영흥사 핑크성당 마사지까지 완벽 글\/사진 락주 아침 8시에 출발하는 진에어를 타고 다낭... 그래도 보통 내가 다니는 <b>여행<\/b>과 차이가 있었다면, 이번 베트남 <b>여행<\/b>은 다낭 보물창고 카페와 함께... ",
+			"bloggername":"락주의 개발새발설레발",
+			"bloggerlink":"https:\/\/blog.naver.com\/metalingus58",
+			"postdate":"20220909"
+		},
+		{
+			"title":"베트남 하노이 <b>여행<\/b> 손오공클라스 ~",
+			"link":"https:\/\/blog.naver.com\/dngudwn?Redirect=Log&logNo=222868597920",
+			"description":"이번에 가족과 함께 다녀온 하노이<b>여행<\/b>. 하노이는 처음가보는 곳이기도 하고 게다가 해외<b>여행<\/b>은 정말 오랜만에 가는 길이기도 해서 처음부터 계획을 확실하게 세우고 출발하기로 했어요. 이번엔 부모님, 그리고... ",
+			"bloggername":"기억하기위한 기록",
+			"bloggerlink":"https:\/\/blog.naver.com\/dngudwn",
+			"postdate":"20220906"
+		},
+		{
+			"title":"파타야골프<b>여행<\/b> 골프러버 모여라",
+			"link":"https:\/\/blog.naver.com\/astromo?Redirect=Log&logNo=222845084790",
+			"description":"파타야골프<b>여행<\/b> 골프러버 모여라 안녕하세요~! 사알짝 주춤하기도 하지만 그래도 작년보다는 공항이... 현지만의 풍미가 있어서 간만에 다시금 파타야골프<b>여행<\/b> 계획을 세워보게 되었어요. 솔직히 자유롭게... ",
+			"bloggername":"知와 사랑",
+			"bloggerlink":"https:\/\/blog.naver.com\/astromo",
+			"postdate":"20220811"
+		},
+		{
+			"title":"하노이 <b>여행<\/b>의 최적의 위치! 서머셋 그랜드 하노이 호텔",
+			"link":"https:\/\/blog.naver.com\/nau2001?Redirect=Log&logNo=222871111020",
+			"description":"하노이 <b>여행<\/b>의 최적의 위치! 서머셋 그랜드 하노이 호텔 글,사진 \/ 와그잡 보통 베트남하면 다낭이나... 평소 무한반복하면서 보고 있는 백종원의 스트리트 푸드파이터를 보고 <b>여행<\/b>을 꿈꾸던 하노이를 드디어... ",
+			"bloggername":"와그잡의 트래블홀릭",
+			"bloggerlink":"https:\/\/blog.naver.com\/nau2001",
+			"postdate":"20220909"
+		},
+		{
+			"title":"뉴욕<b>여행<\/b> 아이랑 3박 4일, 하이라인 파크 \/ 베슬",
+			"link":"https:\/\/blog.naver.com\/tnwjdgnsi?Redirect=Log&logNo=222859279880",
+			"description":"세울 땐 빡빡하지 않은 일정같았는데 <b>여행<\/b> 당시의 컨디션과 7살 아이 동행이라는 변수가 있었다. 계획대로 <b>여행<\/b>을 한 첫째날 숙소에 돌아와 아이에 맞춘 일정으로 변경을 했다. 아이가 좋아하는 전망대를... ",
+			"bloggername":"스윗빈리즈,일상기록_",
+			"bloggerlink":"https:\/\/blog.naver.com\/tnwjdgnsi",
+			"postdate":"20220827"
+		},
+		{
+			"title":"<b>여행<\/b> 인플루언서 선정 꿀팁 이벤트와 맞팬 함께해요",
+			"link":"https:\/\/blog.naver.com\/0watergirl0?Redirect=Log&logNo=222859187966",
+			"description":"이웃님들 드디어 저에게도 이런 날이 왔어요 제가 드디어 <b>여행<\/b> 인플루언서 선정되었어요 꺄아아아아... 끝에 <b>여행<\/b> 인플루언서 선정이 되었고 이번에는 2달간의 긴 기다림의 시간이 있었답니다 2020년에 2번과... ",
+			"bloggername":"여행하는 엄마생활",
+			"bloggerlink":"https:\/\/blog.naver.com\/0watergirl0",
+			"postdate":"20220826"
+		},
+		{
+			"title":"베트남 푸꾸옥 <b>여행<\/b> 딘커우사원 포함 구경했던 곳",
+			"link":"https:\/\/blog.naver.com\/smnsmnsmn?Redirect=Log&logNo=222869458525",
+			"description":"베트남 푸꾸옥 <b>여행<\/b> 딘커우사원 포함 구경했던 곳 안녕하세요 싸와디쌤입니다  오랜만에 다녀온 푸꾸옥 <b>여행<\/b> 포스팅을 해보려고 해요. 푸꾸옥은 어언 10년 전쯤? 푸꾸옥이라는 지명이 저엉말 생소했을 때 친구가... ",
+			"bloggername":"▶ 언제, 어디서든, 행복하기",
+			"bloggerlink":"https:\/\/blog.naver.com\/smnsmnsmn",
+			"postdate":"20220907"
+		},
+		{
+			"title":"일본 북해도 <b>여행<\/b> 홋카이도 <b>여행<\/b> 리조나레 토마무 리조트",
+			"link":"https:\/\/blog.naver.com\/parangusl_?Redirect=Log&logNo=222805448412",
+			"description":"홋카이도 <b>여행<\/b> 북해도는 겨울에 가야 멋지다고 생각하는 분들 계실 텐데요. 일본 북해도 <b>여행<\/b> 녹음 짙은 여름날도 근사하답니다. 홋카이도 호시노 리조트 토마무 리조트 다녀온 후기 들려드릴게요. 홋카이도... ",
+			"bloggername":"당신의 일상은 안녕한가요?",
+			"bloggerlink":"https:\/\/blog.naver.com\/parangusl_",
+			"postdate":"20220826"
+		}
+	]
+}

--- a/SearchApp/SearchAppTests/APIResults/image.json
+++ b/SearchApp/SearchAppTests/APIResults/image.json
@@ -1,0 +1,78 @@
+{
+	"lastBuildDate":"Mon, 12 Sep 2022 15:39:01 +0900",
+	"total":10257655,
+	"start":1,
+	"display":10,
+	"items":[
+		{
+			"title":"대만 가오슝 컨딩 후기 - 여행 카테고리",
+			"link":"https:\/\/img.theqoo.net\/img\/COGEa.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/img.theqoo.net\/img\/COGEa.jpg&type=b150",
+			"sizeheight":"600",
+			"sizewidth":"1200"
+		},
+		{
+			"title":"[4월 릴레이] 여행 릴레이~ - 풋셀 커뮤니티",
+			"link":"https:\/\/footsell.com\/g2\/data\/og_image\/relay\/21996.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/footsell.com\/g2\/data\/og_image\/relay\/21996.jpg&type=b150",
+			"sizeheight":"630",
+			"sizewidth":"1200"
+		},
+		{
+			"title":"에스테이트 데니스 베이 여행의 모든 것! 유명 관광지부터 숨겨진 보석같은 여행지를 찾아 나만의 여행을 떠나자. 특가 호텔과 리뷰는 기본! | 익스피디아",
+			"link":"https:\/\/mediaim.expedia.com\/destination\/2\/8c34cae988105669655515a419a04f99.jpg?impolicy=fcrop&w=1040&h=580&q=mediumHigh",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/mediaim.expedia.com\/destination\/2\/8c34cae988105669655515a419a04f99.jpg?impolicy=fcrop&w=1040&h=580&q=mediumHigh&type=b150",
+			"sizeheight":"580",
+			"sizewidth":"1040"
+		},
+		{
+			"title":"여행 중 신고다닌 신발들(스압주의) - 풋셀 커뮤니티",
+			"link":"https:\/\/footsell.com\/g2\/data\/file\/m42\/view_thumbnail\/mania-done-1641817268_0hO6xyaq_553EA3CC-40C6-4CEC-B87C-EDBE64DB51BA.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/footsell.com\/g2\/data\/file\/m42\/view_thumbnail\/mania-done-1641817268_0hO6xyaq_553EA3CC-40C6-4CEC-B87C-EDBE64DB51BA.jpg&type=b150",
+			"sizeheight":"932",
+			"sizewidth":"700"
+		},
+		{
+			"title":"제주 여행 2일째입니다 - DVDPrime",
+			"link":"https:\/\/dvdprime.com\/g2\/data\/file\/comm\/view_thumbnail\/mania-done-1643167925_WFPzUDE4_20220126_120007.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/dvdprime.com\/g2\/data\/file\/comm\/view_thumbnail\/mania-done-1643167925_WFPzUDE4_20220126_120007.jpg&type=b150",
+			"sizeheight":"494",
+			"sizewidth":"660"
+		},
+		{
+			"title":"임신 시기별 태담 태교 | 태교여행 시기",
+			"link":"http:\/\/post.phinf.naver.net\/MjAyMTExMDVfOTgg\/MDAxNjM2MDgyMzg3MDgx.Xam7v-VvBgqjYVUjuaiy5f-7LzBaD-bLI5hmeBJT4mQg.s0g3KfUq1TVzz9dgikeAkfYxSsPMK4T-wry2zTQQvcEg.JPEG\/IbfsjhF9YjdBQosh_yyCxyIeQUYA.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/common\/?src=http:\/\/post.phinf.naver.net\/MjAyMTExMDVfOTgg\/MDAxNjM2MDgyMzg3MDgx.Xam7v-VvBgqjYVUjuaiy5f-7LzBaD-bLI5hmeBJT4mQg.s0g3KfUq1TVzz9dgikeAkfYxSsPMK4T-wry2zTQQvcEg.JPEG\/IbfsjhF9YjdBQosh_yyCxyIeQUYA.jpg&type=b150",
+			"sizeheight":"960",
+			"sizewidth":"1280"
+		},
+		{
+			"title":"[4월 릴레이] 여행 릴레이~ - 풋셀 커뮤니티",
+			"link":"https:\/\/footsell.com\/g2\/data\/file\/relay\/view_thumbnail\/mania-done-1650581613_jw9xckJH_20220130_140230.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/footsell.com\/g2\/data\/file\/relay\/view_thumbnail\/mania-done-1650581613_jw9xckJH_20220130_140230.jpg&type=b150",
+			"sizeheight":"700",
+			"sizewidth":"700"
+		},
+		{
+			"title":"당일치기 제주도! - 여행 카테고리",
+			"link":"https:\/\/img.theqoo.net\/img\/ETBwR.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/img.theqoo.net\/img\/ETBwR.jpg&type=b150",
+			"sizeheight":"675",
+			"sizewidth":"1200"
+		},
+		{
+			"title":"괌 왔는데.. - 여행 카테고리",
+			"link":"https:\/\/img.theqoo.net\/img\/OGZwx.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/sunny\/?src=https:\/\/img.theqoo.net\/img\/OGZwx.jpg&type=b150",
+			"sizeheight":"900",
+			"sizewidth":"1200"
+		},
+		{
+			"title":"가족여행을 계획 중이라면 오클랜드, 몰디브, 교토는 어떠세요?",
+			"link":"http:\/\/post.phinf.naver.net\/MjAyMjA4MjlfMjA2\/MDAxNjYxNzUzMjIwODEy.MWP7nb0YsULCvQhA6cusMcdUmsE6_lY1g-l9R4o_Qssg.lSK4fjSRBc7u2peEazF9WvPcvRZgseQu56Kgh9g_Jawg.JPEG\/IzHL4KAxVy9B7v60GN1vY9nvCE_8.jpg",
+			"thumbnail":"https:\/\/search.pstatic.net\/common\/?src=http:\/\/post.phinf.naver.net\/MjAyMjA4MjlfMjA2\/MDAxNjYxNzUzMjIwODEy.MWP7nb0YsULCvQhA6cusMcdUmsE6_lY1g-l9R4o_Qssg.lSK4fjSRBc7u2peEazF9WvPcvRZgseQu56Kgh9g_Jawg.JPEG\/IzHL4KAxVy9B7v60GN1vY9nvCE_8.jpg&type=b150",
+			"sizeheight":"2848",
+			"sizewidth":"4288"
+		}
+	]
+}

--- a/SearchApp/SearchAppTests/APIResults/news.json
+++ b/SearchApp/SearchAppTests/APIResults/news.json
@@ -1,0 +1,78 @@
+{
+	"lastBuildDate":"Mon, 12 Sep 2022 15:37:53 +0900",
+	"total":4509143,
+	"start":1,
+	"display":10,
+	"items":[
+		{
+			"title":"달라진 PCR 검사…청주 국제선 재개되나",
+			"originallink":"http:\/\/www.ggilbo.com\/news\/articleView.html?idxno=933363",
+			"link":"http:\/\/www.ggilbo.com\/news\/articleView.html?idxno=933363",
+			"description":"▲ 인천국제공항에서 <b>여행<\/b>객 탑승을 기다리는 대한항공 여객기. 정은한 기자 입국 전 유전자증폭(PCR) 검사... 출입국 규제가 완화되자 잠재수요로 머물던 저가 <b>여행<\/b>객들이 움직이고 있다. 정부가 입국 전 PCR 검사 폐지를... ",
+			"pubDate":"Mon, 12 Sep 2022 15:32:00 +0900"
+		},
+		{
+			"title":"일본 <b>여행<\/b>, 이제 풀리나…“관광객 비자면제·개인<b>여행<\/b> 허용 검토”",
+			"originallink":"http:\/\/www.kukinews.com\/newsView\/kuk202209120023",
+			"link":"http:\/\/www.kukinews.com\/newsView\/kuk202209120023",
+			"description":"그는 관광객 비자 면제와 개인 <b>여행<\/b> 허용을 언급하면서 “완화를 위해 확실히 검토한다”고 덧붙였다. 일본은 2020년 3월부터 코로나19를 이유로 외국인 입국을 막아왔다. 올 3월부터 입국을 재개했지만, 입국 상한선을... ",
+			"pubDate":"Mon, 12 Sep 2022 15:32:00 +0900"
+		},
+		{
+			"title":"뉴질랜드, 코로나 규제 사실상 철폐…병원 마스크 착용·확진자 7일 격리는 유...",
+			"originallink":"https:\/\/view.asiae.co.kr\/article\/2022091215302009605",
+			"link":"https:\/\/n.news.naver.com\/mnews\/article\/277\/0005146021?sid=104",
+			"description":"아울러 그는 외국에서 들어온 <b>여행<\/b>자와 항공기 승무원들의 입국 전 백신 접종도 요구하지 않을 것이라고 했다. 다만, 입국자들에 대한 코로나19 검사는 권장할 것이라고 밝혔다. 뉴질랜드는 봉쇄령 등 2020년부터... ",
+			"pubDate":"Mon, 12 Sep 2022 15:30:00 +0900"
+		},
+		{
+			"title":"[오늘의 금시세]순금(24K) 한돈, 18K, 14K, 은 등 9월 12일 금값과 환율!",
+			"originallink":"http:\/\/www.jejuilbo.net\/news\/articleView.html?idxno=190362",
+			"link":"http:\/\/www.jejuilbo.net\/news\/articleView.html?idxno=190362",
+			"description":"수출이 늘어나거나 외국인들의 한국<b>여행<\/b> 그리고 외국인 투자가 늘어나면 외환 공급이 증가하기 때문에... 한국의 수입증가, 국민들의 외국<b>여행<\/b> 증가 그리고 자본의 유출이 일어나면 외환 수요가 증가하기 때문에 환율이... ",
+			"pubDate":"Mon, 12 Sep 2022 15:30:00 +0900"
+		},
+		{
+			"title":"홍콩·일본서 즐기던 &apos;응커피&apos;, 스타필드 코엑스몰에 국내 첫 오픈",
+			"originallink":"http:\/\/news.mt.co.kr\/mtview.php?no=2022091214334890668",
+			"link":"https:\/\/n.news.naver.com\/mnews\/article\/008\/0004793569?sid=101",
+			"description":"국내에서는 로고의 모양이 &apos;응&apos;을 닮아 일명 &apos;응커피&apos;라는 애칭으로 불리며 홍콩, 일본, 싱가포르, 태국 등 해외에 있는 아라비카 커피 매장이 <b>여행<\/b> 필수 코스로 여겨질 만큼 인기다. 최상급 원두를 사용해... ",
+			"pubDate":"Mon, 12 Sep 2022 15:28:00 +0900"
+		},
+		{
+			"title":"경북문화관광공사, 추석 연휴 경주 보문관광단지 8만여 명 방문",
+			"originallink":"http:\/\/www.betanews.net:8080\/article\/1360901.html",
+			"link":"http:\/\/www.betanews.net:8080\/article\/1360901.html",
+			"description":"한편, 이번 연휴동안 공사 임직원들은 경북을 찾는 관광객들의 즐겁고 안전한 <b>여행<\/b>을 돕기 위해 총괄 상황실 설치, 방역전담반 운영, 영업장별 관리책임자 지정, 관광지 안내와 질서계도를 위해 연인원 340명이 비상근무를... ",
+			"pubDate":"Mon, 12 Sep 2022 15:26:00 +0900"
+		},
+		{
+			"title":"제주항공, 보잉 &apos;B737-8&apos; 40대 내년부터 순차 도입",
+			"originallink":"https:\/\/www.dailian.co.kr\/news\/view\/1151515\/?sc=Naver",
+			"link":"https:\/\/n.news.naver.com\/mnews\/article\/119\/0002638320?sid=101",
+			"description":"단일 기종 및 기단 현대화 작업을 통한 항공기 운용 효율성 확보를 통해 LCC 사업모델에서 더 높은 수준의 경쟁력을 확보함으로써 항공<b>여행<\/b> 회복기 시장 선도 기업의 위상을 갖춘다는 계획이다. 제주항공 관계자는... ",
+			"pubDate":"Mon, 12 Sep 2022 15:24:00 +0900"
+		},
+		{
+			"title":"이르면 올가을부터 일본 자유<b>여행<\/b> 가능해진다",
+			"originallink":"https:\/\/www.seoul.co.kr\/news\/newsView.php?id=20220912500066&wlog_tag3=naver",
+			"link":"https:\/\/n.news.naver.com\/mnews\/article\/081\/0003300892?sid=104",
+			"description":"이르면 올가을부터 일본 자유<b>여행<\/b>이 가능해질 전망이다. 일본 정부가 2020년 3월 코로나19 확산 후 제한한 외국인의 일본 <b>여행<\/b>을 2년여 만에 전면 재개하는 방향으로 검토하고 있다. 일본 정부 부대변인인 기하라 세이지... ",
+			"pubDate":"Mon, 12 Sep 2022 15:24:00 +0900"
+		},
+		{
+			"title":"“멱살 잡혔습니다…” 유명 방송인이 올린 &apos;증거 사진&apos;, 급속 확산 중 (+이유...",
+			"originallink":"https:\/\/www.wikitree.co.kr\/articles\/788447",
+			"link":"https:\/\/www.wikitree.co.kr\/articles\/788447",
+			"description":"이들 부부 인스타그램에는 제주도 <b>여행<\/b> 사진이 올라오고 있다. 최동석-박지윤 부부는 2009년 9월 11일 결혼식을 올렸다. 방송계 대표 &apos;잉꼬부부&apos;로 팬들에게 사랑받고 있다. 2010년생 딸과 2014년생 아들이 있다.",
+			"pubDate":"Mon, 12 Sep 2022 15:24:00 +0900"
+		},
+		{
+			"title":"청도군, 지역 대표 카페 20곳 수록 카페 가이드북 발간",
+			"originallink":"https:\/\/news.imaeil.com\/page\/view\/2022091215003288283",
+			"link":"https:\/\/n.news.naver.com\/mnews\/article\/088\/0000774686?sid=004",
+			"description":"청도군은 카페 가이드북을 청도군<b>여행<\/b>자센터, 관광안내소 4개소에 비치하고 투어버스 및 각종 축제에 배포할 예정이다. 또한 오는 18일까지 청도문화관광 SNS(인스타그램 청도핫플)를 통해 가이드북 발행 기념 이벤트를... ",
+			"pubDate":"Mon, 12 Sep 2022 15:20:00 +0900"
+		}
+	]
+}


### PR DESCRIPTION
## 수정 사항
- SearchType을 Model 그룹의 별도 파일로 분리
- 검색 결과 파싱을 위해 APIResult 구조 추가
- 각 카테고리 별로 json 파싱 로직 추가
   - [json 결과값 테스트코드 파일에 추가
- 결과 업데이트는 메인 스레드에서 하도록 수정
   > Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.

## 추후 추가 사항
- 에러 로직 추가