### PR TITLE
json 데이터에 html 특수 문자가 내려오는 부분 치환 처리

### DIFF
--- a/SearchApp/SearchApp/HighlightKeyword.swift
+++ b/SearchApp/SearchApp/HighlightKeyword.swift
@@ -15,9 +15,7 @@ class HighlightKeyword {
     }
     
     func highlighting(string: String) -> AttributedString {
-        let removedTagString = removeBTag(string: string)
-        
-        var attributedString = AttributedString(removedTagString)
+        var attributedString = AttributedString(string)
         let ranges = attributedString.ranges(of: keyword)
         
         for range in ranges {
@@ -25,11 +23,6 @@ class HighlightKeyword {
         }
         
         return attributedString
-    }
-    
-    private func removeBTag(string: String) -> String {
-        return string.replacingOccurrences(of: "<b>", with: "")
-            .replacingOccurrences(of: "</b>", with: "")
     }
 }
 
@@ -45,5 +38,21 @@ private extension AttributedString {
         }
         
         return ranges
+    }
+}
+
+
+extension String {
+    init?(htmlEncodedString: String) {
+        guard let data = htmlEncodedString.data(using: .utf8) else { return nil }
+        
+        let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
+            .documentType: NSAttributedString.DocumentType.html,
+            .characterEncoding: String.Encoding.utf8.rawValue
+        ]
+        
+        guard let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil) else { return nil }
+        
+        self.init(attributedString.string)
     }
 }

--- a/SearchApp/SearchApp/Models/Blog.swift
+++ b/SearchApp/SearchApp/Models/Blog.swift
@@ -8,10 +8,32 @@
 import Foundation
 
 struct Blog: Codable, Hashable {
+    enum CodingKeys: String, CodingKey {
+        case title, link, description, bloggername, bloggerlink, postdate
+    }
+    
     var title: String
     var link: String
     var description: String
     var bloggername: String
     var bloggerlink: String
     var postdate: String        //"postdate":"20220912"
+}
+
+extension Blog {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let decodedTitle = try container.decode(String.self, forKey: .title)
+        self.title = String(htmlEncodedString: decodedTitle) ?? ""
+        
+        self.link = try container.decode(String.self, forKey: .link)
+        
+        let decodedDescription = try container.decode(String.self, forKey: .description)
+        self.description = String(htmlEncodedString: decodedDescription) ?? ""
+        
+        self.bloggername = try container.decode(String.self, forKey: .bloggername)
+        self.bloggerlink = try container.decode(String.self, forKey: .bloggerlink)
+        self.postdate = try container.decode(String.self, forKey: .postdate)
+    }
 }

--- a/SearchApp/SearchApp/Models/News.swift
+++ b/SearchApp/SearchApp/Models/News.swift
@@ -8,16 +8,37 @@
 import Foundation
 
 struct News: Codable, Hashable {
+    enum CodingKeys: String, CodingKey {
+        case title, link, description, pubDate
+    }
+    
     var title: String
     var link: String
     var description: String
     var pubDate: String     // "pubDate":"Mon, 12 Sep 2022 15:30:00 +0900"
 }
 
+extension News {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let decodedTitle = try container.decode(String.self, forKey: .title)
+        self.title = String(htmlEncodedString: decodedTitle) ?? ""
+        
+        self.link = try container.decode(String.self, forKey: .link)
+        
+        let decodedDescription = try container.decode(String.self, forKey: .description)
+        self.description = String(htmlEncodedString: decodedDescription) ?? ""
+        
+        self.pubDate = try container.decode(String.self, forKey: .pubDate)
+    }
+}
+
+
 extension Date {
     var stringValue: String {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "YY/MM/dd"
+        dateFormatter.dateFormat = "YYYYMMdd"
         
         return dateFormatter.string(from: self)
     }

--- a/SearchApp/SearchApp/Models/Photo.swift
+++ b/SearchApp/SearchApp/Models/Photo.swift
@@ -8,9 +8,27 @@
 import Foundation
 
 struct Photo: Codable, Hashable {
+    enum CodingKeys: String, CodingKey {
+        case title, link, thumbnail, sizewidth, sizeheight
+    }
+    
     var title: String
     var link: String
     var thumbnail: String
     var sizewidth: String
     var sizeheight: String
+}
+
+extension Photo {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let decodedTitle = try container.decode(String.self, forKey: .title)
+        self.title = String(htmlEncodedString: decodedTitle) ?? ""
+        
+        self.link = try container.decode(String.self, forKey: .link)
+        self.thumbnail = try container.decode(String.self, forKey: .thumbnail)
+        self.sizewidth = try container.decode(String.self, forKey: .sizewidth)
+        self.sizeheight = try container.decode(String.self, forKey: .sizeheight)
+    }
 }


### PR DESCRIPTION
## 수정사항
- String의 extension으로 html을 Encode 된 문자열로 변경하도록 하는 failable initializer 생성
- API 결과를 파싱할 때 뉴스, 이미지, 블로그의 결과에서 title과 description에 대해 htmlEncodedString을 적용하도록 수정