### PR TITLE
검색 화면에서 textfield의 return key를 눌러도 검색이 되도록 수정

### DIFF
--- a/SearchApp/SearchApp/Views/Main/SearchBoxView.swift
+++ b/SearchApp/SearchApp/Views/Main/SearchBoxView.swift
@@ -9,24 +9,32 @@ import SwiftUI
 
 struct SearchBoxView: View {
     @State private var keyword: String = ""
+    @State private var isActiveResultView: Bool = false
     
     var body: some View {
         HStack(spacing: 0) {
-            //TODO: Enter - 검색 API 조회
             TextField("Input Search Text", text: $keyword)
                 .frame(height: 50)
                 .padding(.leading, 10)
-            
+                .disableAutocorrection(true)        // 단어 자동수정 방지
+                .submitLabel(.search)
+                .onSubmit {
+                    isActiveResultView = true
+                }
+                
             Button(action: {
                 // TODO: keyword 빈 값인지 확인 -> 알럿 노출
+                isActiveResultView = true
             }, label: {
-                NavigationLink(destination: ResultMainView(keyword: $keyword)) {
-                    Label("Search", systemImage: "magnifyingglass")
-                        .labelStyle(.iconOnly)
-                        .imageScale(.medium)
-                        .foregroundColor(.orange)
-                        .padding()
-                }
+                Label("Search", systemImage: "magnifyingglass")
+                    .labelStyle(.iconOnly)
+                    .imageScale(.medium)
+                    .foregroundColor(.orange)
+                    .padding()
+            })
+            
+            NavigationLink("", isActive: $isActiveResultView, destination: {
+                ResultMainView(keyword: $keyword)
             })
         }
         .border(.orange, width: 2)


### PR DESCRIPTION
## 수정 사항
- 검색 화면에서 textfield의 return key를 눌러도 검색이 되도록 수정 - NavigationLink 코드를 분리해 isActive의 값에 따라 검색 결과 화면으로 넘어가도록 수정

## 추후 변경 사항
- 검색어 체크 로직 추가 및 테스트 코드 작성